### PR TITLE
Add missing Injective implementations

### DIFF
--- a/libs/base/Control/Function.idr
+++ b/libs/base/Control/Function.idr
@@ -2,4 +2,9 @@ module Control.Function
 
 public export
 interface Injective (f : a -> b) where
-  injective : f x = f y -> x = y
+  constructor MkInjective
+  injective : {x, y : a} -> f x = f y -> x = y
+
+public export
+inj : (f : a -> b) -> Injective f => {x, y : a} -> f x = f y -> x = y
+inj _ = injective

--- a/libs/base/Data/Fin.idr
+++ b/libs/base/Data/Fin.idr
@@ -61,14 +61,18 @@ finToNat : Fin n -> Nat
 finToNat FZ = Z
 finToNat (FS k) = S $ finToNat k
 
-||| `finToNat` is injective
-export
 finToNatInjective : (fm : Fin k) -> (fn : Fin k) -> (finToNat fm) = (finToNat fn) -> fm = fn
 finToNatInjective FZ     FZ     _    = Refl
 finToNatInjective (FS _) FZ     Refl impossible
 finToNatInjective FZ     (FS _) Refl impossible
 finToNatInjective (FS m) (FS n) prf  =
   cong FS $ finToNatInjective m n $ injective prf
+
+||| `finToNat` is injective
+%hint
+export
+finToNatInj : Injective Fin.finToNat
+finToNatInj = MkInjective (finToNatInjective _ _)
 
 export
 Cast (Fin n) Nat where

--- a/libs/base/Data/List/Elem.idr
+++ b/libs/base/Data/List/Elem.idr
@@ -1,6 +1,7 @@
 module Data.List.Elem
 
 import Decidable.Equality
+import Control.Function
 
 %default total
 
@@ -24,9 +25,10 @@ export
 Uninhabited (There e = Here) where
   uninhabited Refl impossible
 
+%hint
 export
-thereInjective : {0 e1, e2 : Elem x xs} -> There e1 = There e2 -> e1 = e2
-thereInjective Refl = Refl
+thereInjective : Injective {a=Elem x xs} (There {x} {y} {xs})
+thereInjective = MkInjective (\Refl => Refl)
 
 export
 DecEq (Elem x xs) where
@@ -35,7 +37,7 @@ DecEq (Elem x xs) where
   decEq (There later) Here = No absurd
   decEq (There this) (There that) with (decEq this that)
     decEq (There this) (There this) | Yes Refl  = Yes Refl
-    decEq (There this) (There that) | No contra = No (contra . thereInjective)
+    decEq (There this) (There that) | No contra = No (contra . injective)
 
 export
 Uninhabited (Elem {a} x []) where

--- a/libs/base/Data/List1.idr
+++ b/libs/base/Data/List1.idr
@@ -1,6 +1,7 @@
 module Data.List1
 
 import public Data.Zippable
+import Control.Function
 
 %default total
 
@@ -163,6 +164,16 @@ Ord a => Ord (List1 a) where
 export
 consInjective : (x ::: xs) === (y ::: ys) -> (x === y, xs === ys)
 consInjective Refl = (Refl, Refl)
+
+%hint
+export
+consHeadInj : {x : a} -> Injective (x :::)
+consHeadInj = MkInjective (\Refl => Refl)
+
+%hint
+export
+consTailInj : {ys : List a} -> Injective (::: ys)
+consTailInj = MkInjective (\Refl => Refl)
 
 ------------------------------------------------------------------------
 -- Zippable

--- a/libs/base/Data/SnocList/Elem.idr
+++ b/libs/base/Data/SnocList/Elem.idr
@@ -2,6 +2,7 @@ module Data.SnocList.Elem
 
 import Data.SnocList
 import Decidable.Equality
+import Control.Function
 
 ||| A proof that some element is found in a list.
 public export
@@ -9,7 +10,7 @@ data Elem : a -> SnocList a -> Type where
   ||| A proof that the element is at the head of the list
   Here : Elem x (sx :< x)
   ||| A proof that the element is in the tail of the list
-  There : Elem x sx -> Elem x (sx :< y)
+  There : {0 x, y : a} -> Elem x sx -> Elem x (sx :< y)
 
 export
 Uninhabited (Here = There e) where
@@ -24,9 +25,10 @@ Uninhabited (Elem {a} x [<]) where
   uninhabited Here impossible
   uninhabited (There p) impossible
 
+%hint
 export
-thereInjective : {0 e1, e2 : Elem x sx} -> There e1 = There e2 -> e1 = e2
-thereInjective Refl = Refl
+thereInjective : Injective {a=Elem x sx} (There {x} {y} {sx})
+thereInjective = MkInjective (\Refl => Refl)
 
 export
 DecEq (x `Elem` sx) where
@@ -35,7 +37,7 @@ DecEq (x `Elem` sx) where
   decEq (There _) Here = No absurd
   decEq (There y) (There z) with (decEq y z)
     decEq (There y) (There y) | Yes Refl = Yes Refl
-    decEq (There y) (There z) | No neq = No $ neq . thereInjective
+    decEq (There y) (There z) | No neq = No $ neq . injective
 
 ||| Remove the element at the given position.
 public export

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -7,6 +7,7 @@ import public Data.Fin
 import public Data.Zippable
 
 import Decidable.Equality
+import Control.Function
 
 %default total
 
@@ -33,9 +34,18 @@ lengthCorrect []        = Refl
 lengthCorrect (_ :: xs) = rewrite lengthCorrect xs in Refl
 
 ||| If two vectors are equal, their heads and tails are equal
-export
 vectInjective : {0 xs : Vect n a} -> {0 ys : Vect m b} -> x::xs = y::ys -> (x = y, xs = ys)
 vectInjective Refl = (Refl, Refl)
+
+%hint
+export
+consVectHeadInj : {x : a} -> Injective (Vect.(::) x)
+consVectHeadInj = MkInjective (\Refl => Refl)
+
+%hint
+export
+consVectTailInj : {xs : Vect n a} -> Injective (\x => Vect.(::) x xs)
+consVectTailInj = MkInjective (\Refl => Refl)
 
 --------------------------------------------------------------------------------
 -- Indexing into vectors

--- a/libs/base/Decidable/Equality.idr
+++ b/libs/base/Decidable/Equality.idr
@@ -117,7 +117,7 @@ DecEq a => DecEq (List1 a) where
   decEq (x ::: xs) (y ::: ys) with (decEq x y)
     decEq (x ::: xs) (y ::: ys) | No contra = No (contra . fst . consInjective)
     decEq (x ::: xs) (y ::: ys) | Yes eqxy with (decEq xs ys)
-      decEq (x ::: xs) (y ::: ys) | Yes eqxy | No contra = No (contra . snd . consInjective)
+      decEq (x ::: xs) (y ::: ys) | Yes eqxy | No contra = No (contra . (rewrite sym eqxy in injective))
       decEq (x ::: xs) (y ::: ys) | Yes eqxy | Yes eqxsys = Yes (cong2 (:::) eqxy eqxsys)
 
 -- TODO: Other prelude data types

--- a/libs/contrib/Data/Nat/Factor.idr
+++ b/libs/contrib/Data/Nat/Factor.idr
@@ -123,7 +123,7 @@ multOneSoleNeutral (S k) (S (S j)) prf =
         rewrite plusCommutative k j in
         rewrite sym $ plusAssociative j k (k * S j) in
         rewrite sym $ multRightSuccPlus k (S j) in
-        injective {f = S} $ injective prf
+        inj S $ injective prf
 
 ||| If a is a factor of b and b is a factor of a, then a = b.
 public export


### PR DESCRIPTION
Hi @nickdrozd 

I've noticed this PR was good but was missing a couple of implementations, also the signature of `Injective` was a bit restrictive for some proofs, was that on purpose?

I've added `inj` as I've had the need for it myself because the function `f` could not be inferred for my injectivity proofs 